### PR TITLE
RDKECMF-208 Fix native build errors

### DIFF
--- a/.github/workflows/native_full_build.yml
+++ b/.github/workflows/native_full_build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build systemtimemgr component in github rdkcentral
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+      image: ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest
 
     steps:
       - name: Checkout code

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -19,17 +19,6 @@
 
 WORKDIR=`pwd`
 
-cd $WORKDIR
-#Build libsyswrapper
-git clone https://github.com/rdkcentral/libSyscallWrapper.git
-
-cd libSyscallWrapper
-autoupdate
-autoreconf -i
-./configure --prefix=${RDKLOGGER_INSTALL_DIR}
-make
-make install
-
 apt-get update
 apt-get install -y libjsonrpccpp-dev
 

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -19,11 +19,11 @@
 
 WORKDIR=`pwd`
 
+cd $WORKDIR
 #Build libsyswrapper
-cd ${RDKLOGGER_ROOT}
 git clone https://github.com/rdkcentral/libSyscallWrapper.git
 
-cd ${RDKLOGGER_ROOT}/libSyscallWrapper
+cd libSyscallWrapper
 autoupdate
 autoreconf -i
 ./configure --prefix=${RDKLOGGER_INSTALL_DIR}

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -19,28 +19,6 @@
 
 WORKDIR=`pwd`
 
-export RDKLOGGER_ROOT=/usr
-export RDKLOGGER_INSTALL_DIR=${RDKLOGGER_ROOT}/local
-mkdir -p $RDKLOGGER_INSTALL_DIR
-cd $RDKLOGGER_ROOT
-#Build rdk-logger
-git clone https://github.com/rdkcentral/rdk_logger.git
-
-cd rdk_logger
-
-#build log4c
-wget --no-check-certificate https://sourceforge.net/projects/log4c/files/log4c/1.2.4/log4c-1.2.4.tar.gz/download -O log4c-1.2.4.tar.gz
-tar -xvf log4c-1.2.4.tar.gz
-cd log4c-1.2.4
-./configure
-make clean && make && make install
-
-cd ${RDKLOGGER_ROOT}/rdk_logger
-export PKG_CONFIG_PATH=${RDKLOGGER_INSTALL_DIR}/rdk_logger/log4c-1.2.4:$PKG_CONFIG_PATH
-autoreconf -i
-./configure
-make clean && make && make install
-
 #Build libsyswrapper
 cd ${RDKLOGGER_ROOT}
 git clone https://github.com/rdkcentral/libSyscallWrapper.git

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -36,9 +36,6 @@
 using namespace std::chrono;
 
 
-
-
-
 SysTimeMgr* SysTimeMgr::pInstance = NULL;
 recursive_mutex SysTimeMgr::g_state_mutex;
 mutex SysTimeMgr::g_instance_mutex;


### PR DESCRIPTION
Switch to use docker-device-mgt-service-test container and update cov_build script accordingly. 