### PR TITLE
RDKEMW-15665 : Handle deepsleep case with chronyd

### DIFF
--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -642,9 +642,10 @@ void SysTimeMgr::deepsleepoff()
         ret = v_secure_system("/bin/systemctl is-active --quiet chronyd.service");
 		if (ret == 0) {
             // chronyd is running
-            RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
+			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc burst\n",__FUNCTION__,__LINE__);
 			v_secure_system("/usr/sbin/chronyc burst 2/4");
-			sleep(1);
+			sleep(3);
+			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
             v_secure_system("/usr/sbin/chronyc makestep");
         } else {
             RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:Neither systemd-timesyncd nor chronyd is running, skipping time sync actions.\n",__FUNCTION__,__LINE__);

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -643,7 +643,7 @@ void SysTimeMgr::deepsleepoff()
 		if (ret == 0) {
             // chronyd is running
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc burst\n",__FUNCTION__,__LINE__);
-			v_secure_system("/usr/sbin/chronyc burst 2/4");
+			v_secure_system("/usr/sbin/chronyc burst 3/4");
 			sleep(3);
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
             v_secure_system("/usr/sbin/chronyc makestep");

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -644,6 +644,7 @@ void SysTimeMgr::deepsleepoff()
             // chronyd is running
             RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
 			v_secure_system("/usr/sbin/chronyc burst 2/4");
+			sleep(1);
             v_secure_system("/usr/sbin/chronyc makestep");
         } else {
             RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:Neither systemd-timesyncd nor chronyd is running, skipping time sync actions.\n",__FUNCTION__,__LINE__);

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -1,4 +1,4 @@
-F/*
+/*
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -649,7 +649,7 @@ void SysTimeMgr::deepsleepoff()
             }
 
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, waiting for source selection\n",__FUNCTION__,__LINE__);
-            ret = v_secure_system("/usr/sbin/chronyc waitsync");
+            ret = v_secure_system("/usr/sbin/chronyc waitsync 10 0 0 1");
             if (ret != 0) {
                 RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:chronyc waitsync failed with code %d\n",__FUNCTION__,__LINE__, ret);
             }

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -647,9 +647,9 @@ void SysTimeMgr::deepsleepoff()
             if (ret != 0) {
                 RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:chronyc burst failed with code %d\n",__FUNCTION__,__LINE__, ret);
             }
-
+            // Wait for chronyd to synchronize with at least 1 source, for up to 20 tries.
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, waiting for source selection\n",__FUNCTION__,__LINE__);
-            ret = v_secure_system("/usr/sbin/chronyc waitsync 10 0 0 1");
+            ret = v_secure_system("/usr/sbin/chronyc waitsync 20 0 0 1");
             if (ret != 0) {
                 RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:chronyc waitsync failed with code %d\n",__FUNCTION__,__LINE__, ret);
             }

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -280,7 +280,7 @@ void SysTimeMgr::runPathMonitor()
 		return;
 	}
 	
-	wd = inotify_add_watch(inotifyFd, m_directory.c_str(), IN_DELETE|IN_MODIFY|IN_ATTRIB);
+	wd = inotify_add_watch(inotifyFd, m_directory.c_str(), IN_DELETE|IN_MODIFY|IN_ATTRIB|IN_CREATE);
 	if (wd == -1)
 	{
 		RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:Unable to create Watchi descriptor. Exiting thread \n",__FUNCTION__,__LINE__);

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -643,13 +643,22 @@ void SysTimeMgr::deepsleepoff()
 		if (ret == 0) {
             // chronyd is running
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc burst\n",__FUNCTION__,__LINE__);
-			v_secure_system("/usr/sbin/chronyc burst 3/4");
+			ret = v_secure_system("/usr/sbin/chronyc burst 3/4");
+            if (ret != 0) {
+                RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:chronyc burst failed with code %d\n",__FUNCTION__,__LINE__, ret);
+            }
 
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, waiting for source selection\n",__FUNCTION__,__LINE__);
-            v_secure_system("/usr/sbin/chronyc waitsync");
+            ret = v_secure_system("/usr/sbin/chronyc waitsync");
+            if (ret != 0) {
+                RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:chronyc waitsync failed with code %d\n",__FUNCTION__,__LINE__, ret);
+            }
 			
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
-            v_secure_system("/usr/sbin/chronyc makestep");
+            ret = v_secure_system("/usr/sbin/chronyc makestep");
+            if (ret != 0) {
+                RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:chronyc makestep failed with code %d\n",__FUNCTION__,__LINE__, ret);
+            }
         } else {
             RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:Neither systemd-timesyncd nor chronyd is running, skipping time sync actions.\n",__FUNCTION__,__LINE__);
         }

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -1,4 +1,4 @@
-/*
+F/*
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -643,6 +643,7 @@ void SysTimeMgr::deepsleepoff()
 		if (ret == 0) {
             // chronyd is running
             RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
+			v_secure_system("/usr/sbin/chronyc burst 2/4");
             v_secure_system("/usr/sbin/chronyc makestep");
         } else {
             RDK_LOG(RDK_LOG_WARN,LOG_SYSTIME,"[%s:%d]:Neither systemd-timesyncd nor chronyd is running, skipping time sync actions.\n",__FUNCTION__,__LINE__);

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -644,7 +644,10 @@ void SysTimeMgr::deepsleepoff()
             // chronyd is running
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc burst\n",__FUNCTION__,__LINE__);
 			v_secure_system("/usr/sbin/chronyc burst 3/4");
-			sleep(3);
+
+			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, waiting for source selection\n",__FUNCTION__,__LINE__);
+            v_secure_system("/usr/sbin/chronyc waitsync");
+			
 			RDK_LOG(RDK_LOG_INFO,LOG_SYSTIME,"[%s:%d]:chronyd is active, performing chronyc makestep\n",__FUNCTION__,__LINE__);
             v_secure_system("/usr/sbin/chronyc makestep");
         } else {

--- a/systimemgr.cpp
+++ b/systimemgr.cpp
@@ -280,7 +280,7 @@ void SysTimeMgr::runPathMonitor()
 		return;
 	}
 	
-	wd = inotify_add_watch(inotifyFd, m_directory.c_str(), IN_DELETE|IN_MODIFY|IN_ATTRIB|IN_CREATE);
+	wd = inotify_add_watch(inotifyFd, m_directory.c_str(), IN_DELETE|IN_MODIFY|IN_ATTRIB);
 	if (wd == -1)
 	{
 		RDK_LOG(RDK_LOG_ERROR,LOG_SYSTIME,"[%s:%d]:Unable to create Watchi descriptor. Exiting thread \n",__FUNCTION__,__LINE__);


### PR DESCRIPTION
Reason for change:
Handle the deepsleepoff scenario by executing chronyc burst to select the source and chronyc makestep to ensure time synchronization after wake.
Test Procedure:
Validate that the system time is synchronized correctly after waking from deep sleep.
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)